### PR TITLE
Up version to 1.5.1, add OpenSSL dependency

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ import os
 class LibZipConan(ConanFile):
     name = "libzip"
     description = "A C library for reading, creating, and modifying zip archives"
-    version = "1.4.0"
+    version = "1.5.1"
     url = "https://github.com/bincrafters/conan-libzip"
     homepage = "https://github.com/nih-at/libzip"
     license = "BSD"
@@ -31,6 +31,9 @@ class LibZipConan(ConanFile):
     def requirements(self):
         if self.options.with_bzip2:
             self.requires.add("bzip2/1.0.6@conan/stable")
+
+        if self.settings.os == "Windows" or self.settings.os == "Linux":
+            self.requires("OpenSSL/[>=1.0]@conan/stable")
 
     def configure_cmake(self):
         cmake = CMake(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,8 +18,12 @@ class LibZipConan(ConanFile):
     source_subfolder = "source_subfolder"
     build_subfolder = "build_subfolder"
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "with_bzip2": [True, False]}
-    default_options = "shared=False", "with_bzip2=True"
+    options = {
+        "shared": [True, False],
+        "with_bzip2": [True, False],
+        "with_openssl": [True, False]
+    }
+    default_options = "shared=False", "with_bzip2=True", "with_openssl=True"
     requires = "zlib/1.2.11@conan/stable"
 
     def source(self):
@@ -32,11 +36,12 @@ class LibZipConan(ConanFile):
         if self.options.with_bzip2:
             self.requires.add("bzip2/1.0.6@conan/stable")
 
-        if self.settings.os == "Windows" or self.settings.os == "Linux":
+        if self.options.with_openssl:
             self.requires("OpenSSL/[>=1.0]@conan/stable")
 
     def configure_cmake(self):
         cmake = CMake(self)
+        cmake.definitions["ENABLE_OPENSSL"] = self.options.with_openssl
         cmake.definitions["BUILD_SHARED_LIBS"] = self.options.shared
         cmake.configure()
         return cmake


### PR DESCRIPTION
Update to 1.5.1
Since 1.5, libzip requires specific crypto library. This works with OpenSSL but might also work with LibreSSL.